### PR TITLE
Load scene data from FBX tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ maya_3dsmax_pbr = []
 rgb = "0.8.33"
 anyhow = "1.0.58"
 glam = { version = "0.21", features = ["mint"] }
+mint = "0.5"
 # fbxcel-dom = { version = "0.0.9", path = "../fbxcel-dom" }
 fbxcel-dom = "0.0.9"
 
@@ -30,8 +31,8 @@ features = [
   "bevy_scene",
 ]
 
-# [dev-dependencies]
-# bevy-inspector-egui = "0.11"
+[dev-dependencies]
+bevy-inspector-egui = "0.12"
 
 [dev-dependencies.bevy]
 version = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ This material loader do not work with every type of texture files,
 the textures must be readable from CPU and have each component (color channel)
 be exactly 8 bits (such as PNG).
 
+### Version matrix
+
+| bevy | latest supporting version      |
+|------|--------|
+| 0.8  | 0.1.0-dev |
+
 ### Limitations
 
 > **NOTE**: If you find more limitations, file an issue!
@@ -38,6 +44,7 @@ be exactly 8 bits (such as PNG).
 - [X] Support arbitrary material loading.
 - [X] Support Maya's PBR
 - [X] Proper scaling based on FBX config scale ([#10](https://github.com/HeavyRain266/bevy_fbx/issues/10))
+- [X] Load complex scenes with a transform tree hierarchy
 - [ ] Proper handling of Coordinate system
 - [ ] Support `bevy_animation` as optional feature ([#13](https://github.com/HeavyRain266/bevy_fbx/issues/13))
 - [ ] Provide examples with usage of complex scenes ([#6](https://github.com/HeavyRain266/bevy_fbx/issues/6))
@@ -46,8 +53,8 @@ be exactly 8 bits (such as PNG).
 
 ### Examples
 
-- cube: Load simple cube with point light
-- scene_viwer: Load any FBX files from `/path/to/file.fbx`, defaults to `assets/cube.fbx`
+- `cube`: Load simple cube with point light
+- `scene_viewer`: Load any FBX files from `/path/to/file.fbx`, defaults to `assets/cube.fbx`
 
 Run example:
 
@@ -58,6 +65,30 @@ cargo run --example <example_name>
 # Faster asset loading
 cargu run --example <example_name> --release --features bevy/dynamic
 ```
+
+### Contributing
+
+FBX is a very widely used and flexible file format.
+We currently expect most models **to not load properly**.
+We cannot test how `bevy_fbx` handles the export formats of every software out there.
+If your model loads properly, thank your lucky start,
+if you encounter any issue please do the following:
+
+- Try opening the model using the `scene_viewer` (run `cargo run --example scene_viewer --release -- /path/to/file.fbx`)
+  (if your file has textures, make sure to enable the correct file formats using `--features bevy/png bevy/jpg bevy/tga` etc.)
+- If it fails, open an issue on our Github repo with a screenshot in the scene viewer
+  and a screenshot of how the model should look like
+  <https://github.com/HeavyRain266/bevy_fbx/issues/new/choose>
+- Ideally provide a download link to your FBX model
+
+#### Further troubleshooting tools
+
+If you want to help us figure out how to load a particularly tricky model,
+the following tools may be useful:
+
+- <https://github.com/lo48576/fbx_objects_depviz>
+- <https://github.com/lo48576/fbx-tree-view>
+- Use the `profile` feature with those instructions: https://github.com/bevyengine/bevy/blob/main/docs/profiling.md
 
 ## License
 

--- a/dev_docs/fbx_tree_printer.rs
+++ b/dev_docs/fbx_tree_printer.rs
@@ -6,12 +6,12 @@ fn print_children(depth: usize, children: Children) {
             print!("{name} ", name = child.name(),);
         }
         let attr_display = |att: &AttributeValue| match att {
-            AttributeValue::Bool(v) => format!("{v}"),
-            AttributeValue::I16(v) => format!("{v}"),
-            AttributeValue::I32(v) => format!("{v}"),
-            AttributeValue::I64(v) => format!("{v}"),
-            AttributeValue::F32(v) => format!("{v}"),
-            AttributeValue::F64(v) => format!("{v}"),
+            AttributeValue::Bool(v) => v.to_string(),
+            AttributeValue::I16(v) => v.to_string(),
+            AttributeValue::I32(v) => v.to_string(),
+            AttributeValue::I64(v) => v.to_string(),
+            AttributeValue::F32(v) => v.to_string(),
+            AttributeValue::F64(v) => v.to_string(),
             AttributeValue::ArrBool(_) => "[bool]".to_owned(),
             AttributeValue::ArrI32(_) => "[i32]".to_owned(),
             AttributeValue::ArrI64(_) => "[i64]".to_owned(),

--- a/dev_docs/fbx_tree_printer.rs
+++ b/dev_docs/fbx_tree_printer.rs
@@ -1,0 +1,43 @@
+fn print_children(depth: usize, children: Children) {
+    let show_depth = depth * 3;
+    for child in children {
+        print!("{space:>depth$}", space = "", depth = show_depth);
+        if child.name().len() > 1 {
+            print!("{name} ", name = child.name(),);
+        }
+        let attr_display = |att: &AttributeValue| match att {
+            AttributeValue::Bool(v) => format!("{v}"),
+            AttributeValue::I16(v) => format!("{v}"),
+            AttributeValue::I32(v) => format!("{v}"),
+            AttributeValue::I64(v) => format!("{v}"),
+            AttributeValue::F32(v) => format!("{v}"),
+            AttributeValue::F64(v) => format!("{v}"),
+            AttributeValue::ArrBool(_) => "[bool]".to_owned(),
+            AttributeValue::ArrI32(_) => "[i32]".to_owned(),
+            AttributeValue::ArrI64(_) => "[i64]".to_owned(),
+            AttributeValue::ArrF32(_) => "[f32]".to_owned(),
+            AttributeValue::ArrF64(_) => "[f64]".to_owned(),
+            AttributeValue::String(s) => s.clone(),
+            AttributeValue::Binary(_) => "[u8]".to_owned(),
+        };
+        print!("[");
+        for (i, attr) in child.attributes().iter().map(attr_display).enumerate() {
+            // if matches!(i, 1 | 2 | 3) {
+            //     continue;
+            // }
+            if i == 0 {
+                print!("{attr}: ");
+            } else {
+                print!("{attr}, ");
+            }
+        }
+        println!("]");
+        if child.children().next().is_some() {
+            println!("{:>depth$}{{", "", depth = show_depth);
+        }
+        print_children(depth + 1, child.children());
+        if child.children().next().is_some() {
+            println!("{:>depth$}}}", "", depth = show_depth);
+        }
+    }
+}

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -1,4 +1,9 @@
-use bevy::{prelude::*, render::camera::ScalingMode, window::close_on_esc};
+use bevy::{
+    log::{Level, LogSettings},
+    prelude::*,
+    render::camera::ScalingMode,
+    window::close_on_esc,
+};
 use bevy_fbx::FbxPlugin;
 
 fn main() {
@@ -10,6 +15,10 @@ fn main() {
         height: 574.0,
 
         ..default()
+    });
+    app.insert_resource(LogSettings {
+        level: Level::INFO,
+        filter: "bevy_fbx=trace,wgpu=warn".to_owned(),
     });
 
     app.add_plugins(DefaultPlugins);

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -5,6 +5,7 @@ use bevy::{
     window::close_on_esc,
 };
 use bevy_fbx::FbxPlugin;
+use bevy_inspector_egui::WorldInspectorPlugin;
 
 fn main() {
     let mut app = App::new();
@@ -15,17 +16,16 @@ fn main() {
         height: 574.0,
 
         ..default()
-    });
-    app.insert_resource(LogSettings {
+    })
+    .insert_resource(LogSettings {
         level: Level::INFO,
         filter: "bevy_fbx=trace,wgpu=warn".to_owned(),
-    });
-
-    app.add_plugins(DefaultPlugins);
-    app.add_plugin(FbxPlugin);
-
-    app.add_startup_system(setup);
-    app.add_system(close_on_esc);
+    })
+    .add_plugins(DefaultPlugins)
+    .add_plugin(WorldInspectorPlugin::new())
+    .add_plugin(FbxPlugin)
+    .add_startup_system(setup)
+    .add_system(close_on_esc);
 
     app.run();
 }
@@ -38,33 +38,22 @@ fn setup(mut cmd: Commands, asset_server: Res<AssetServer>) {
         projection: OrthographicProjection {
             scale: 3.0,
             scaling_mode: ScalingMode::FixedVertical(2.0),
-
             ..default()
         }
         .into(),
-
         transform: Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-
         ..default()
     });
 
     // light
     cmd.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(3.0, 8.0, 5.0),
-
         ..default()
     });
 
     // Cube
-    cmd.spawn_bundle(TransformBundle {
-        local: Transform::from_xyz(0.0, 0.0, 0.0),
-        global: GlobalTransform::identity(),
-    })
-    .with_children(|parent| {
-        parent.spawn_bundle(SceneBundle {
-            scene: cube,
-
-            ..default()
-        });
+    cmd.spawn_bundle(SceneBundle {
+        scene: cube,
+        ..default()
     });
 }

--- a/examples/scene_viewer.rs
+++ b/examples/scene_viewer.rs
@@ -47,8 +47,8 @@ Controls:
         brightness: 1.0 / 5.0f32,
     })
     .insert_resource(LogSettings {
-        level: Level::INFO,
-        ..Default::default()
+        level: Level::WARN,
+        filter: "bevy_fbx=info".to_owned(),
     })
     .insert_resource(AssetServerSettings {
         asset_folder: std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
@@ -112,7 +112,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
     commands.spawn_bundle(SceneBundle {
         scene: asset_server.load(&scene_path),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/scene_viewer.rs
+++ b/examples/scene_viewer.rs
@@ -1,3 +1,5 @@
+// This file is heavily inspired by the Bevy scene_viewer.rs
+// found in the repository's tools folder.
 //! A simple FBX scene viewer made with Bevy.
 //!
 //! Just run `cargo run --release --example scene_viewer /path/to/model.fbx#Scene`,
@@ -15,7 +17,7 @@ use bevy::{
     window::close_on_esc,
 };
 use bevy_fbx::FbxPlugin;
-// use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::WorldInspectorPlugin;
 
 use std::f32::consts::TAU;
 
@@ -59,7 +61,7 @@ Controls:
         ..default()
     })
     .add_plugins(DefaultPlugins)
-    // .add_plugin(WorldInspectorPlugin::new())
+    .add_plugin(WorldInspectorPlugin::new())
     .add_plugin(FbxPlugin)
     .add_startup_system(setup)
     .add_system(update_lights)
@@ -110,10 +112,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         ..default()
     });
-    commands.spawn_bundle(SceneBundle {
-        scene: asset_server.load(&scene_path),
-        ..default()
-    });
+    commands
+        .spawn_bundle(SceneBundle {
+            scene: asset_server.load(&scene_path),
+            ..default()
+        })
+        .insert(Name::new(scene_path));
 }
 
 const SCALE_STEP: f32 = 0.1;

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,10 +1,12 @@
 use bevy::{
     asset::Handle,
     pbr::StandardMaterial,
+    prelude::Transform,
     reflect::TypeUuid,
     render::{mesh::Mesh as BevyMesh, texture::Image},
-    utils::{HashMap, HashSet},
+    utils::HashMap,
 };
+use fbxcel_dom::fbxcel::tree::v7400::NodeId;
 
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "966d55c0-515b-4141-97a1-de30ac8ee44c"]
@@ -13,6 +15,18 @@ pub struct FbxMesh {
     pub bevy_mesh_handles: Vec<Handle<BevyMesh>>,
     pub materials: Vec<Handle<StandardMaterial>>,
 }
+
+/// The data loaded from a FBX scene.
+///
+/// Note that the loader spawns a [`Scene`], with all the
+/// FBX nodes spawned as entities (with their corresponding [`Name`] set)
+/// in the ECS,
+/// and you should absolutely use the ECS entities over
+/// manipulating this data structure.
+/// It is provided publicly, because it might be a good store for strong handles.
+///
+/// [`Scene`]: bevy::scene::Scene
+/// [`Name`]: bevy::core::Name
 #[derive(Default, Debug, Clone, TypeUuid)]
 #[uuid = "e87d49b6-8d6a-43c7-bb33-5315db8516eb"]
 pub struct FbxScene {
@@ -20,5 +34,24 @@ pub struct FbxScene {
     pub bevy_meshes: HashMap<Handle<BevyMesh>, String>,
     pub materials: HashMap<String, Handle<StandardMaterial>>,
     pub textures: HashMap<String, Handle<Image>>,
-    pub meshes: HashSet<Handle<FbxMesh>>,
+    pub meshes: HashMap<NodeId, Handle<FbxMesh>>,
+    pub hierarchy: HashMap<NodeId, FbxObject>,
+    pub root: Option<NodeId>,
+}
+
+/// An FBX object in the scene tree.
+///
+/// This serves as a node in the transform hierarchy.
+#[derive(Default, Debug, Clone)]
+pub struct FbxObject {
+    pub name: Option<String>,
+    pub transform: Transform,
+    /// The children of this node.
+    ///
+    /// # Notes
+    /// Not all [`NodeId`] declared as child of an `FbxObject`
+    /// are relevant to Bevy.
+    /// Meaning that you won't find the `NodeId` in `hierarchy` or `meshes`
+    /// `HashMap`s of the [`FbxScene`] structure.
+    pub children: Vec<NodeId>,
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,7 +6,7 @@ use bevy::{
     render::{mesh::Mesh as BevyMesh, texture::Image},
     utils::HashMap,
 };
-use fbxcel_dom::fbxcel::tree::v7400::NodeId;
+use fbxcel_dom::v7400::object::ObjectId;
 
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "966d55c0-515b-4141-97a1-de30ac8ee44c"]
@@ -34,9 +34,9 @@ pub struct FbxScene {
     pub bevy_meshes: HashMap<Handle<BevyMesh>, String>,
     pub materials: HashMap<String, Handle<StandardMaterial>>,
     pub textures: HashMap<String, Handle<Image>>,
-    pub meshes: HashMap<NodeId, Handle<FbxMesh>>,
-    pub hierarchy: HashMap<NodeId, FbxObject>,
-    pub root: Option<NodeId>,
+    pub meshes: HashMap<ObjectId, Handle<FbxMesh>>,
+    pub hierarchy: HashMap<ObjectId, FbxObject>,
+    pub root: Option<ObjectId>,
 }
 
 /// An FBX object in the scene tree.
@@ -53,5 +53,5 @@ pub struct FbxObject {
     /// are relevant to Bevy.
     /// Meaning that you won't find the `NodeId` in `hierarchy` or `meshes`
     /// `HashMap`s of the [`FbxScene`] structure.
-    pub children: Vec<NodeId>,
+    pub children: Vec<ObjectId>,
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,9 +1,6 @@
 use bevy::{
-    asset::Handle,
-    pbr::StandardMaterial,
-    prelude::Transform,
+    prelude::{Handle, Image, Mesh, StandardMaterial, Transform},
     reflect::TypeUuid,
-    render::{mesh::Mesh as BevyMesh, texture::Image},
     utils::HashMap,
 };
 use fbxcel_dom::v7400::object::ObjectId;
@@ -12,7 +9,7 @@ use fbxcel_dom::v7400::object::ObjectId;
 #[uuid = "966d55c0-515b-4141-97a1-de30ac8ee44c"]
 pub struct FbxMesh {
     pub name: Option<String>,
-    pub bevy_mesh_handles: Vec<Handle<BevyMesh>>,
+    pub bevy_mesh_handles: Vec<Handle<Mesh>>,
     pub materials: Vec<Handle<StandardMaterial>>,
 }
 
@@ -31,12 +28,12 @@ pub struct FbxMesh {
 #[uuid = "e87d49b6-8d6a-43c7-bb33-5315db8516eb"]
 pub struct FbxScene {
     pub name: Option<String>,
-    pub bevy_meshes: HashMap<Handle<BevyMesh>, String>,
+    pub bevy_meshes: HashMap<Handle<Mesh>, String>,
     pub materials: HashMap<String, Handle<StandardMaterial>>,
     pub textures: HashMap<String, Handle<Image>>,
     pub meshes: HashMap<ObjectId, Handle<FbxMesh>>,
     pub hierarchy: HashMap<ObjectId, FbxObject>,
-    pub root: Option<ObjectId>,
+    pub roots: Vec<ObjectId>,
 }
 
 /// An FBX object in the scene tree.

--- a/src/data.rs
+++ b/src/data.rs
@@ -46,9 +46,9 @@ pub struct FbxObject {
     /// The children of this node.
     ///
     /// # Notes
-    /// Not all [`NodeId`] declared as child of an `FbxObject`
+    /// Not all [`ObjectId`] declared as child of an `FbxObject`
     /// are relevant to Bevy.
-    /// Meaning that you won't find the `NodeId` in `hierarchy` or `meshes`
+    /// Meaning that you won't find the `ObjectId` in `hierarchy` or `meshes`
     /// `HashMap`s of the [`FbxScene`] structure.
     pub children: Vec<ObjectId>,
 }

--- a/src/fbx_transform.rs
+++ b/src/fbx_transform.rs
@@ -1,0 +1,219 @@
+//! Handles FBX transform propagation, and translation
+//! into bevy Transform and GlobalTransform.
+
+// a bit of trivia on how transform is encoded in FBX:
+// rotation: EulerXYZ in degrees, three steps: PreRotation, Lcl Rotation, PostRotation
+// https://forums.autodesk.com/t5/fbx-forum/maya-quot-rotate-axis-quot-vs-fbx-quot-postrotation-quot/td-p/4168814
+// https://help.autodesk.com/cloudhelp/2017/ENU/FBX-Developer-Help/files/GUID-C35D98CB-5148-4B46-82D1-51077D8970EE.htm
+// http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/cpp_ref/class_fbx_node.html
+// https://help.autodesk.com/cloudhelp/2016/ENU/FBX-Developer-Help/cpp_ref/_view_scene_2_draw_scene_8cxx-example.html#a78
+// (see "Pivot Management" section for last link)
+//
+// The following code is somewhat taken from:
+// https://stackoverflow.com/questions/34452946/how-can-i-get-the-correct-position-of-fbx-mesh
+// which itself is taken from:
+// https://help.autodesk.com/cloudhelp/2016/ENU/FBX-Developer-Help/cpp_ref/_transformations_2main_8cxx-example.html#a30
+//
+// FbxNode also has {Rotation,Scaling,Translation}Active propreties,
+// what is their meaning?
+// - https://forums.autodesk.com/t5/fbx-forum/rotationactive/td-p/4267206
+// - https://help.autodesk.com/cloudhelp/2016/ENU/FBX-Developer-Help/cpp_ref/class_fbx_node.html
+use std::f32::consts::TAU;
+
+use anyhow::Result;
+use bevy::math::{DVec3, EulerRot};
+use bevy::prelude::{Mat4, Transform, Vec3};
+use fbxcel_dom::v7400::object::{model::ModelHandle, property::ObjectProperties, ObjectHandle};
+
+use crate::utils::fbx_extend::{InheritType, Loadable};
+
+#[derive(Copy, Clone, Debug)]
+struct Translation(Vec3);
+impl Translation {
+    fn mat(&self) -> Mat4 {
+        Mat4::from_translation(self.0)
+    }
+    fn from_double(p: DVec3) -> Translation {
+        Self(p.as_vec3())
+    }
+}
+
+// FBX encodes rotations in Eulers (customizable order) in degrees,
+// and for some reasons, it needs to be negated and then inverted.
+#[derive(Copy, Clone, Debug)]
+struct Rotation(Vec3, EulerRot);
+impl Rotation {
+    fn from_euler(euler: EulerRot, angles: DVec3) -> Self {
+        Rotation(angles.as_vec3() * -(TAU / 360.0), euler)
+    }
+    fn mat(&self) -> Mat4 {
+        let Vec3 { x, y, z } = self.0;
+        Mat4::from_euler(self.1, x, y, z).inverse()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Scale(Vec3);
+impl Scale {
+    fn mat(&self) -> Mat4 {
+        Mat4::from_scale(self.0)
+    }
+    fn from_double(p: DVec3) -> Scale {
+        Self(p.as_vec3())
+    }
+    const IDENTITY: Self = Self(Vec3::ONE);
+}
+
+#[derive(Clone, Debug)]
+struct NodeScale {
+    pivot: Translation,
+    offset: Translation,
+    local: Scale,
+}
+#[derive(Clone, Debug)]
+struct NodeRotation {
+    pivot: Translation,
+    offset: Translation,
+    local: Rotation,
+    pre: Rotation,
+    post: Rotation,
+}
+/// Handle the awkward translation from FBX to Bevy transform.
+///
+/// The transform propagation in FBX is _way too flexible_,
+/// and doesn't translate well to bevy's simple global/matrix+local/TRS.
+/// So it's necessary to compute the actual global position
+/// based on the FBX formula and do a second pass
+/// where we set the local transform infered
+/// from the computed FBX global position.
+#[derive(Clone, Debug)]
+struct FbxNodeTransformInfo {
+    rotation: NodeRotation,
+    translation: Translation,
+    scale: NodeScale,
+    inherit_type: InheritType,
+}
+impl FbxNodeTransformInfo {
+    // if you were wondering: "Lcl" stands for "Local"
+    // FIXME: Non-zero {Rotation,Scaling}{Pivot,Offset} is untested.
+    // TODO: Geometric{Translation,Scaling,Rotation}
+    // (see docs.autodesk.com and stackoverflow.com links at top of this file)
+    fn from_object(object: ObjectHandle) -> Result<Self> {
+        fn load<T: Loadable>(p: ObjectProperties, attribute: &str) -> Result<T> {
+            T::get_property(p, attribute)
+        }
+        let p = object.properties_by_native_typename("FbxNode");
+        let e = load(p, "RotationOrder")?;
+        Ok(FbxNodeTransformInfo {
+            rotation: NodeRotation {
+                pivot: Translation::from_double(load(p, "RotationPivot")?),
+                offset: Translation::from_double(load(p, "RotationOffset")?),
+                local: Rotation::from_euler(e, load(p, "Lcl Rotation")?),
+                pre: Rotation::from_euler(e, load(p, "PreRotation")?),
+                post: Rotation::from_euler(e, load(p, "PostRotation")?),
+            },
+            translation: Translation::from_double(load(p, "Lcl Translation")?),
+            scale: NodeScale {
+                pivot: Translation::from_double(load(p, "ScalingPivot")?),
+                offset: Translation::from_double(load(p, "ScalingOffset")?),
+                local: Scale::from_double(load(p, "Lcl Scaling")?),
+            },
+            inherit_type: load(p, "InheritType")?,
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct LocalScale(Scale);
+
+// This is similar to mat.to_scale_rotation_translation()
+// but takes into account shear operations (meaning: rotation followed by non-uniform scale)
+// The implementation is the one used in the Autodesk scene translation example file.
+fn get_reverse_transform(mat: Mat4) -> (Mat4, Mat4) {
+    let mat_q = Mat4::from_quat;
+    let mat_t = Mat4::from_translation;
+    let (_, rotation, translation) = mat.to_scale_rotation_translation();
+    let rotation = mat_q(rotation);
+    let shear_scale = mat * rotation.inverse() * mat_t(translation).inverse();
+    (shear_scale, rotation)
+}
+
+// NOTE: there were no thought about performance put into this,
+// the goal of this method is to get something working ASAP,
+// performance can wait.
+// I particularly dislike the amount of matrix inversion and multiplication this incures.
+fn global_transform(node: FbxNodeTransformInfo, parent: Option<FbxTransform>) -> Mat4 {
+    let mat_t = Mat4::from_translation;
+    let rot = node.rotation;
+    let scale = node.scale;
+    let rotation = rot.pre.mat() * rot.local.mat() * rot.post.mat();
+
+    let FbxTransform {
+        global: parent_transform,
+        local_scale: local_parent_scale,
+    } = parent.unwrap_or_default();
+
+    let (parent_shear_scale, parent_rotation) = get_reverse_transform(parent_transform);
+    let parent_nonlocal_scale = parent_shear_scale * local_parent_scale.mat().inverse();
+
+    let inherited_rot_scale = match node.inherit_type {
+        InheritType::RrSs => parent_rotation * rotation * parent_shear_scale * scale.local.mat(),
+        InheritType::RSrs => parent_rotation * parent_shear_scale * rotation * scale.local.mat(),
+        InheritType::Rrs => parent_rotation * rotation * parent_nonlocal_scale * scale.local.mat(),
+    };
+    let with_off_piv = |offset: Translation, pivot: Translation, transform| {
+        offset.mat() * pivot.mat() * transform * pivot.mat().inverse()
+    };
+    let translation = node.translation.mat()
+        * with_off_piv(rot.offset, rot.pivot, rotation)
+        * with_off_piv(scale.offset, scale.pivot, scale.local.mat());
+    let translation = translation.to_scale_rotation_translation().2;
+    let global_translation = parent_transform.transform_vector3(translation);
+    mat_t(global_translation * 0.625) * inherited_rot_scale
+}
+
+/// Fbx global transform, including parent local scale to compute
+/// the children's transform.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FbxTransform {
+    local_scale: Scale,
+    pub(crate) global: Mat4,
+}
+impl Default for FbxTransform {
+    fn default() -> Self {
+        FbxTransform {
+            local_scale: Scale::IDENTITY,
+            global: Mat4::IDENTITY,
+        }
+    }
+}
+impl FbxTransform {
+    pub(crate) fn from_node(node: ModelHandle, parent: Option<FbxTransform>) -> Self {
+        let transform = FbxNodeTransformInfo::from_object(*node).unwrap();
+        FbxTransform::from_fbxtrans(transform, parent)
+    }
+    fn from_fbxtrans(trans: FbxNodeTransformInfo, parent: Option<FbxTransform>) -> Self {
+        FbxTransform {
+            local_scale: trans.scale.local,
+            global: global_transform(trans, parent),
+        }
+    }
+    // Problem: `Self` is the _global_ position of fbx node, not local.
+    // An FBX local transform can't be translated directly into a bevy Transform,
+    // so we need to compute the global transform and work backward from there.
+    // 1. we have parent(FbxGlobalTransform)
+    // 2. we just computed child(FbxGlobalTransform)
+    // 3. GlobalTransform = FbxGlobalTransform
+    // 4. We need to find the child(Transform):
+    //    - from bevy's transform mat: child(GlobalTransform) = parent(GlobalTransform) * child(Transform)
+    //    - We have: child(GlobalTransform) and parent(GlobalTransform)
+    //    - child(Transform) = child(GlobalTransform) * parent(GlobalTransform)¯¹
+    pub(crate) fn to_local_transform(&self, parent: Option<Mat4>) -> Transform {
+        let mat = if let Some(parent) = parent {
+            self.global * parent.inverse()
+        } else {
+            self.global
+        };
+        Transform::from_matrix(mat)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub use data::{FbxMesh, FbxScene};
 pub use loader::FbxLoader;
 
 pub(crate) mod data;
+pub(crate) mod fbx_transform;
 pub(crate) mod loader;
 pub mod material_loader;
 pub(crate) mod utils;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -53,11 +53,6 @@ const FBX_TO_BEVY_SCALE_FACTOR: f32 = 0.01;
 
 pub struct Loader<'b, 'w> {
     scene: FbxScene,
-    // TODO: it seems the bistro scene is supposed to be 0.016 it's current size
-    // maybe we are doing something wrong here?
-    // TODO: test with Xo's model to check how it works, maybe
-    // the scale is a relation between OriginalUnitScale and UnitScale, rather
-    // than just UnitScale
     load_context: &'b mut LoadContext<'w>,
     suported_compressed_formats: CompressedImageFormats,
     material_loaders: Vec<MaterialLoader>,
@@ -129,7 +124,7 @@ fn spawn_scene(
         .insert_bundle(TransformBundle::from_transform(Transform::from_scale(
             Vec3::ONE * FBX_TO_BEVY_SCALE_FACTOR * fbx_file_scale,
         )))
-        .insert(Name::new("Fbx scene Root"))
+        .insert(Name::new("Fbx scene root"))
         .with_children(|commands| {
             for root in roots {
                 spawn_scene_rec(*root, commands, hierarchy, models);

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -138,6 +138,10 @@ fn generate_scene_helper(
     }
     entity.with_children(|commands| {
         if let Some(mesh) = models.get(&current) {
+            println!(
+                "material {:?} child of {:?}",
+                &mesh.name, &current_node.name
+            );
             for (mat, bevy_mesh) in mesh.materials.iter().zip(&mesh.bevy_mesh_handles) {
                 let mut entity = commands.spawn_bundle(PbrBundle {
                     mesh: bevy_mesh.clone(),
@@ -150,6 +154,9 @@ fn generate_scene_helper(
             }
         }
         for node_id in &current_node.children {
+            if let Some(foo) = hierarchy.get(node_id) {
+                println!("{:?} child of {:?}", &foo.name, &current_node.name);
+            }
             generate_scene_helper(*node_id, commands, hierarchy, models);
         }
     });

--- a/src/material_loader.rs
+++ b/src/material_loader.rs
@@ -96,6 +96,8 @@ pub const LOAD_LAMBERT_PHONG: MaterialLoader = MaterialLoader {
             .map_or(0.8, |s| (2.0 / (2.0 + s)).sqrt());
         Some(StandardMaterial {
             alpha_mode: if is_transparent { Blend } else { Opaque },
+            // For bistro only
+            // alpha_mode: AlphaMode::Mask(0.8),
             base_color,
             metallic,
             perceptual_roughness: roughness as f32,
@@ -123,7 +125,7 @@ pub const LOAD_FALLBACK: MaterialLoader = MaterialLoader {
             .ok()
             .flatten()
             .map(|c| ColorAdapter(c).into())
-            .unwrap_or(Color::WHITE);
+            .unwrap_or(Color::PINK);
         let metallic = properties
             .specular()
             .ok()

--- a/src/utils/fbx_extend.rs
+++ b/src/utils/fbx_extend.rs
@@ -1,8 +1,9 @@
 //! Collection of temporary extensions to the fbxcell_dom types
 //! until they are merged upstream.
+use bevy::math::{Quat, Vec3};
 
 use fbxcel_dom::{
-    fbxcel::low::v7400::AttributeValue,
+    fbxcel::{low::v7400::AttributeValue, tree::v7400::NodeHandle},
     v7400::{
         object::{
             material::MaterialHandle, property::loaders::PrimitiveLoader, texture::TextureHandle,
@@ -67,5 +68,96 @@ impl<'a> GlobalSettingsExt<'a> for GlobalSettings<'a> {
             AttributeValue::F64(scale) => Some(*scale),
             _ => None,
         }
+    }
+}
+
+// a bit of trivia on how transform is encoded in FBX:
+// rotation: EulerXYZ in degrees, three steps: PreRotation, Lcl Rotation, PostRotation
+// the other: probably mirrors rotation and all have a Pre, Lcl and Post version
+// https://forums.autodesk.com/t5/fbx-forum/maya-quot-rotate-axis-quot-vs-fbx-quot-postrotation-quot/td-p/4168814
+// https://help.autodesk.com/cloudhelp/2017/ENU/FBX-Developer-Help/files/GUID-C35D98CB-5148-4B46-82D1-51077D8970EE.htm
+// http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/cpp_ref/class_fbx_node.html
+// (see "Pivot Management" section for last link)
+pub trait NodeHandleTransformExt<'a> {
+    fn get_vec3(&self, name: &str) -> Option<Vec3>;
+    fn rotation(&self) -> Quat;
+    fn scale(&self) -> Vec3;
+    fn translation(&self) -> Vec3;
+}
+
+// Add `unwrap_or{_default}` to all elements of
+// an expression of the form foo $op bar $op baz ...
+// where `$op` is a math operator such as +, -, *
+macro_rules! op_or {
+    ( default $op:tt ($head:expr $( , $tail:expr )+) ) => {
+        $head.unwrap_or_default() $op op_or!(default $op ( $($tail),* ))
+    };
+    ( default $op:tt ($head:expr) ) => {
+        $head.unwrap_or_default()
+    };
+    ( ($default:expr) $op:tt ($head:expr $( , $tail:expr )+) ) => {
+        $head.unwrap_or($default) $op op_or!(($default) $op ( $($tail),* ))
+    };
+    ( ($default:expr) $op:tt ($head:expr) ) => {
+        $head.unwrap_or($default)
+    };
+}
+// TODO: additional useful fields in the Model node:
+// - "Primary Visibility"
+// - "Casts Shadows"
+// - "Receive Shadows"
+// - "Culling"
+// - "Shading" (seems to always be false though?)
+// TODO: probably need to impl that on ObjectHandle
+// so that it's possible to use `properties_by_native_typename`
+// so that defaults are used when value absent.
+//
+// Also note that "Lcl" stands for "Local"
+impl<'a> NodeHandleTransformExt<'a> for NodeHandle<'a> {
+    fn get_vec3(&self, requested: &str) -> Option<Vec3> {
+        use AttributeValue::{String as Str, F64};
+        let prop = self.first_child_by_name("Properties70")?;
+        let attributes = prop.children().find_map(|c| {
+            let attributes = c.attributes();
+            let is_requested = attributes.first() == Some(&Str(requested.to_owned()));
+            is_requested.then(|| attributes)
+        })?;
+        match attributes {
+            &[.., F64(x), F64(y), F64(z)] => Some(Vec3::new(x as f32, y as f32, z as f32)),
+            _ => None,
+        }
+    }
+    // The formula is: Lcl * Pre * Post^-1
+    fn rotation(&self) -> Quat {
+        use bevy::math::EulerRot::XYZ;
+        let to_quat = |Vec3 { x, y, z }| {
+            Quat::from_euler(XYZ, x.to_radians(), y.to_radians(), z.to_radians())
+        };
+
+        let pre = self.get_vec3("PreRotation").map(to_quat);
+        let value = self.get_vec3("Lcl Rotation").map(to_quat);
+        let post = self
+            .get_vec3("PostRotation")
+            .map(to_quat)
+            .map(Quat::inverse);
+
+        op_or!(default * (value, pre, post))
+    }
+    // The formula is: Lcl * Pre * Post^-1
+    fn scale(&self) -> Vec3 {
+        let pre = self.get_vec3("PreScaling");
+        let value = self.get_vec3("Lcl Scaling");
+        let post = self.get_vec3("PostScaling").map(|v| 1.0 / v);
+
+        op_or!((Vec3::ONE) * (value, pre, post))
+    }
+    // The formula is: Lcl + Pre + Post
+    // (actually not sure "Pre" and "Post" fields exist for translation)
+    fn translation(&self) -> Vec3 {
+        let pre = self.get_vec3("PreTranslation");
+        let value = self.get_vec3("Lcl Translation");
+        let post = self.get_vec3("PostTranslation");
+
+        op_or!(default + (value, pre, post))
     }
 }

--- a/src/utils/fbx_extend.rs
+++ b/src/utils/fbx_extend.rs
@@ -257,16 +257,16 @@ fn is_object_root(object: &ObjectHandle) -> bool {
 }
 
 pub trait ModelTreeRootExt {
-    fn model_root(&self) -> ModelHandle<'_>;
+    fn model_roots(&self) -> Vec<ModelHandle<'_>>;
 }
 impl ModelTreeRootExt for Document {
-    fn model_root(&self) -> ModelHandle<'_> {
+    fn model_roots(&self) -> Vec<ModelHandle<'_>> {
         self.objects()
-            .find(is_object_root)
-            .and_then(|obj| match obj.get_typed() {
+            .filter(is_object_root)
+            .filter_map(|obj| match obj.get_typed() {
                 TypedObjectHandle::Model(o) => Some(*o),
                 _ => None,
             })
-            .unwrap()
+            .collect()
     }
 }

--- a/src/utils/fbx_extend.rs
+++ b/src/utils/fbx_extend.rs
@@ -1,8 +1,7 @@
 //! Collection of temporary extensions to the fbxcell_dom types
 //! until they are merged upstream.
 
-use bevy::math::{DVec2, DVec3, DVec4, Vec2, Vec3, Vec4};
-use glam::EulerRot;
+use bevy::math::{DVec2, DVec3, DVec4, EulerRot, Vec2, Vec3, Vec4};
 use mint::{Vector2, Vector3, Vector4};
 
 use fbxcel_dom::{
@@ -159,7 +158,7 @@ impl TryFrom<i32> for InheritType {
 /// Rotation in FBX is defined as a Vec3 of **degrees**
 /// (not radians) of Tait-Bryan angles (commonly called Euler angles).
 ///
-/// Note that for reasons unbeknownst, the proper translation into quaternions,
+/// Note that for reasons unbeknownst, to translate this into the bevy equivalent,
 /// the euler angles must be negated and the resulting matrix inverted.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, Default, Debug)]

--- a/src/utils/triangulate.rs
+++ b/src/utils/triangulate.rs
@@ -1,19 +1,15 @@
 //! Triangulator.
 
-// TODO: Replace with https://lib.rs/triangulate?
+// TODO: https://github.com/HeavyRain266/bevy_fbx/issues/11
 
 use anyhow::{anyhow, bail};
 use bevy::math::{DVec2, DVec3};
 use fbxcel_dom::v7400::data::mesh::{PolygonVertexIndex, PolygonVertices};
 
-/// Axis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Axis {
-    /// X.
     X,
-    /// Y.
     Y,
-    /// Z.
     Z,
 }
 


### PR DESCRIPTION
Read the FBX transform tree and assign entities for each node in the hierarchy,
computing and setting the bevy `Transform` according to FBX's completely
insane transform propagation algorithm.

Also a few unrelated things (I'm sorry)

This is also a first step toward loading skeleton rigs.

- Correct the way the scene's `UnitScaleFactor` is applied: instead of dividing
  the vertices position by it, we just add the scale to the root node of the scene,
  this also requires dividing by default by 100.0 the scale of all FBX files.
- Add a tool to print the FBX file content in the `dev_docs` directory
- Add a "Contributing" section to the README
- Fixes #26
- The Bistro scene's normals are broken, but this is a bevy bug: https://github.com/bevyengine/bevy/issues/5514