### PR TITLE
Update bevy_mod_fbx to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ mint = "0.5"
 fbxcel-dom = "0.0.9"
 
 [dependencies.bevy]
-version = "0.10"
+version = "^0.15"
 default-features = false
 features = [
   "bevy_pbr",
@@ -34,16 +34,17 @@ features = [
 ]
 
 [dev-dependencies.bevy]
-version = "0.10"
+version = "^0.15"
 default-features = false
 features = [
-  "x11", #"wayland",
-
-  "tga", "dds",
+  "x11",
+  "tga",
+  "dds",
   "bevy_pbr",
   "bevy_render",
   "bevy_winit",
   "bevy_scene",
-  "filesystem_watcher",
-  "bevy_core_pipeline"
+  "file_watcher",
+  "bevy_core_pipeline",
+  "multi_threaded"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ profile = []
 maya_3dsmax_pbr = []
 
 [dependencies]
-rgb = "0.8"
-anyhow = "1.0.58"
-glam = { version = "0.23", features = ["mint"] }
-mint = "0.5"
+rgb = "0.8.50"
+anyhow = "1.0.97"
+glam = { version = "0.30", features = ["mint"] }
+mint = "0.5.9"
 # fbxcel-dom = { version = "0.0.9", path = "../fbxcel-dom" }
-fbxcel-dom = "0.0.9"
+fbxcel-dom = "0.0.10"
 
 [dependencies.bevy]
 version = "^0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_fbx"
-authors = ["Nicola Papale", "HeavyRain266"]
+authors = ["Nicola Papale", "HeavyRain266", "FizzWizZleDazzle"]
 description = "Autodesk Filmbox (*.fbx) loader for Bevy Engine"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -8,7 +8,7 @@ keywords = ["bevy", "bevy_plugin", "fbx_loader"]
 categories = ["game-development"]
 repository = "https://github.com/nicopap/bevy_mod_fbx"
 exclude = ["assets/**/*", "scripts/**/*", ".github/**/*"]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ cargu run --example <example_name> --release --features bevy/dynamic
 
 ### Version matrix
 
-| bevy | bevy_mod_fbx |
-|------|--------------|
-| 0.10 | 0.4          |
-| 0.9  | 0.3          |
-| 0.8  | 0.1.0-dev    |
+| bevy        | bevy_mod_fbx |
+|-------------|--------------|
+| 0.15        | 0.5          |
+| 0.11 - 0.14 | :x:          |
+| 0.10        | 0.4          |
+| 0.9         | 0.3          |
+| 0.8         | 0.1.0-dev    |
 
 ## Contributing
 

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -2,7 +2,7 @@ use bevy::{
     log::{Level, LogPlugin},
     prelude::*,
     render::camera::ScalingMode,
-    window::{close_on_esc, WindowResolution},
+    window::WindowResolution,
 };
 use bevy_mod_fbx::FbxPlugin;
 
@@ -17,6 +17,7 @@ fn main() {
             .set(LogPlugin {
                 level: Level::INFO,
                 filter: "bevy_mod_fbx=trace,wgpu=warn".to_owned(),
+                ..Default::default()
             })
             .set(WindowPlugin {
                 primary_window: Some(Window {
@@ -27,47 +28,40 @@ fn main() {
                 ..default()
             }),
     )
-    .add_plugin(FbxPlugin)
-    .add_startup_system(setup)
-    .add_system(spin_cube)
-    .add_system(close_on_esc);
+    .add_plugins(FbxPlugin)
+    .add_systems(Startup, setup)
+    .add_systems(Update, spin_cube);
 
     app.run();
 }
 
 fn spin_cube(time: Res<Time>, mut query: Query<&mut Transform, With<Spin>>) {
     for mut transform in query.iter_mut() {
-        transform.rotate_local_y(0.3 * time.delta_seconds());
-        transform.rotate_local_x(0.3 * time.delta_seconds());
-        transform.rotate_local_z(0.3 * time.delta_seconds());
+        transform.rotate_local_y(0.3 * time.delta_secs());
+        transform.rotate_local_x(0.3 * time.delta_secs());
+        transform.rotate_local_z(0.3 * time.delta_secs());
     }
 }
 
 fn setup(mut cmd: Commands, asset_server: Res<AssetServer>) {
     // Orthographic camera
-    cmd.spawn(Camera3dBundle {
-        projection: OrthographicProjection {
-            scale: 3.0,
-            scaling_mode: ScalingMode::FixedVertical(2.0),
-            ..default()
-        }
-        .into(),
-        transform: Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    cmd.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 
     // light
-    cmd.spawn(PointLightBundle {
-        transform: Transform::from_xyz(3.0, 8.0, 5.0),
-        ..default()
-    });
+    cmd.spawn((
+        PointLight {
+            intensity: 1000.0,
+            ..default()
+        },
+        Transform::from_xyz(3.0, 8.0, 5.0),
+    ));
 
     // Cube
     cmd.spawn((
-        SceneBundle {
-            scene: asset_server.load("cube.fbx#Scene"),
-            ..default()
-        },
+        SceneRoot ( asset_server.load("cube.fbx#Scene")),
         Spin,
     ));
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,12 +1,13 @@
 use bevy::{
     prelude::{Handle, Image, Mesh, StandardMaterial, Transform},
-    reflect::TypeUuid,
     utils::HashMap,
+    asset::Asset
 };
+use bevy::prelude::TypePath;
 use fbxcel_dom::v7400::object::ObjectId;
 
-#[derive(Debug, Clone, TypeUuid)]
-#[uuid = "966d55c0-515b-4141-97a1-de30ac8ee44c"]
+#[derive(Debug, Clone, Asset, TypePath)]
+//#[uuid = "966d55c0-515b-4141-97a1-de30ac8ee44c"]
 pub struct FbxMesh {
     pub name: Option<String>,
     pub bevy_mesh_handles: Vec<Handle<Mesh>>,
@@ -24,8 +25,8 @@ pub struct FbxMesh {
 ///
 /// [`Scene`]: bevy::scene::Scene
 /// [`Name`]: bevy::core::Name
-#[derive(Default, Debug, Clone, TypeUuid)]
-#[uuid = "e87d49b6-8d6a-43c7-bb33-5315db8516eb"]
+#[derive(Default, Debug, Clone, Asset, TypePath)]
+//#[uuid = "e87d49b6-8d6a-43c7-bb33-5315db8516eb"]
 pub struct FbxScene {
     pub name: Option<String>,
     pub bevy_meshes: HashMap<Handle<Mesh>, String>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+#[derive(Debug, Clone)]
+pub enum FbxLoadingError {
+    IncorrectFileVersion,
+    UnknownError,
+    Other(String),
+}
+
+impl std::error::Error for FbxLoadingError {}
+
+impl std::fmt::Display for FbxLoadingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IncorrectFileVersion => write!(f, "Incorrect file version"),
+            Self::UnknownError => write!(f, "Unknown error"),
+            Self::Other(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl From<std::io::Error> for FbxLoadingError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Other(err.to_string())
+    }
+}

--- a/src/fbx_transform.rs
+++ b/src/fbx_transform.rs
@@ -123,8 +123,8 @@ impl FbxNodeTransformInfo {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub(crate) struct LocalScale(Scale);
+//#[derive(Copy, Clone, Debug)]
+//pub(crate) struct LocalScale(Scale);
 
 // This is similar to mat.to_scale_rotation_translation()
 // but takes into account shear operations (meaning: rotation followed by non-uniform scale)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod fbx_transform;
 pub(crate) mod loader;
 pub mod material_loader;
 pub(crate) mod utils;
+pub(crate) mod error;
 
 use material_loader::MaterialLoader;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{AddAsset, App, Plugin, Resource};
+use bevy::prelude::{App, AssetApp, Plugin, Resource};
 
 pub use data::{FbxMesh, FbxScene};
 pub use loader::FbxLoader;
@@ -37,7 +37,7 @@ impl Default for FbxMaterialLoaders {
 impl Plugin for FbxPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset_loader::<FbxLoader>()
-            .add_asset::<FbxMesh>()
-            .add_asset::<FbxScene>();
+            .init_asset::<FbxMesh>()
+            .init_asset::<FbxScene>();
     }
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -95,7 +95,7 @@ impl AssetLoader for FbxLoader {
     fn load(
         &self,
         reader: &mut dyn Reader,
-        settings: &Self::Settings,
+        _settings: &Self::Settings,
         load_context: &mut LoadContext,
     ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
         Box::pin(async move {
@@ -106,8 +106,7 @@ impl AssetLoader for FbxLoader {
             let maybe_doc =
                 AnyDocument::from_seekable_reader(reader).expect("Failed to load document");
             if let AnyDocument::V7400(_ver, doc) = maybe_doc {
-                let path = load_context.path().to_owned();
-                let mut loader =
+                let loader =
                     Loader::new(self.supported, self.material_loaders.clone(), load_context);
                 match loader.load(*doc).await {
                     Ok(scene) => Ok(scene),
@@ -415,7 +414,7 @@ impl<'b, 'w> Loader<'b, 'w> {
 
                 let handle = self
                     .load_context
-                    .add_labeled_asset(label.to_string(), (material_mesh));
+                    .add_labeled_asset(label.to_string(), material_mesh);
                 self.scene.bevy_meshes.insert(handle.clone(), label);
                 handle
             })
@@ -621,11 +620,11 @@ impl<'b, 'w> Loader<'b, 'w> {
         let image: Result<Image, anyhow::Error> = self.load_video_clip(video_clip_obj).await;
         let mut image = image.context("Failed to load texture image")?;
 
-        /*image.sampler_descriptor = ImageSampler::Descriptor(ImageSamplerDescriptor {
-            address_mode_u,
-            address_mode_v,
+        image.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+            address_mode_u: address_mode_u.into(),
+            address_mode_v: address_mode_v.into(),
             ..Default::default()
-        });*/
+        });
         Ok(image)
     }
 

--- a/src/material_loader.rs
+++ b/src/material_loader.rs
@@ -2,7 +2,8 @@
 use crate::utils::fbx_extend::*;
 
 use bevy::{
-    pbr::{AlphaMode, StandardMaterial},
+    prelude::AlphaMode,
+    pbr::{StandardMaterial},
     prelude::{Color, Handle, Image},
     utils::HashMap,
 };
@@ -125,7 +126,7 @@ pub const LOAD_FALLBACK: MaterialLoader = MaterialLoader {
             .ok()
             .flatten()
             .map(|c| ColorAdapter(c).into())
-            .unwrap_or(Color::PINK);
+            .unwrap_or(Color::WHITE);
         let metallic = properties
             .specular()
             .ok()
@@ -281,6 +282,6 @@ pub const fn default_loader_order() -> &'static [MaterialLoader] {
 struct ColorAdapter(RGB<f64>);
 impl From<ColorAdapter> for Color {
     fn from(ColorAdapter(rgb): ColorAdapter) -> Self {
-        Color::rgb(rgb.r as f32, rgb.g as f32, rgb.b as f32)
+        Color::srgb(rgb.r as f32, rgb.g as f32, rgb.b as f32)
     }
 }

--- a/src/utils/fbx_extend.rs
+++ b/src/utils/fbx_extend.rs
@@ -205,6 +205,98 @@ impl TryFrom<i32> for RotationOrder {
     }
 }
 
+// Add these conversions before the impl_loadable! macro
+trait IntoHelper<T> {
+    fn do_into(&self) -> T;
+}
+
+impl IntoHelper<Vec2> for Vector2<f32> {
+    fn do_into(&self) -> Vec2 { Vec2::new(self.x, self.y) }
+}
+
+impl IntoHelper<DVec2> for Vector2<f64> {
+    fn do_into(&self) -> DVec2 { DVec2::new(self.x, self.y) }
+}
+
+impl IntoHelper<Vec3> for Vector3<f32> {
+    fn do_into(&self) -> Vec3 { Vec3::new(self.x, self.y, self.z) }
+}
+
+impl IntoHelper<DVec3> for Vector3<f64> {
+    fn do_into(&self) -> DVec3 { DVec3::new(self.x, self.y, self.z) }
+}
+
+impl IntoHelper<Vec4> for Vector4<f32> {
+    fn do_into(&self) -> Vec4 { Vec4::new(self.x, self.y, self.z, self.w) }
+}
+
+impl IntoHelper<DVec4> for Vector4<f64> {
+    fn do_into(&self) -> DVec4 { DVec4::new(self.x, self.y, self.z, self.w) }
+}
+
+impl IntoHelper<RGB<f64>> for RGB<f64> {
+    fn do_into(&self) -> RGB<f64> { *self }
+}
+
+impl IntoHelper<RGB<f32>> for RGB<f32> {
+    fn do_into(&self) -> RGB<f32> { *self }
+}
+
+impl IntoHelper<RGBA<f64>> for RGBA<f64> {
+    fn do_into(&self) -> RGBA<f64> { *self }
+}
+
+impl IntoHelper<RGBA<f32>> for RGBA<f32> {
+    fn do_into(&self) -> RGBA<f32> { *self }
+}
+
+impl IntoHelper<bool> for bool {
+    fn do_into(&self) -> bool { *self }
+}
+
+impl IntoHelper<f32> for f32 {
+    fn do_into(&self) -> f32 { *self }
+}
+
+impl IntoHelper<f64> for f64 {
+    fn do_into(&self) -> f64 { *self }
+}
+
+impl IntoHelper<i16> for i16 {
+    fn do_into(&self) -> i16 { *self }
+}
+
+impl IntoHelper<i32> for i32 {
+    fn do_into(&self) -> i32 { *self }
+}
+
+impl IntoHelper<i64> for i64 {
+    fn do_into(&self) -> i64 { *self }
+}
+
+impl IntoHelper<u16> for u16 {
+    fn do_into(&self) -> u16 { *self }
+}
+
+impl IntoHelper<u32> for u32 {
+    fn do_into(&self) -> u32 { *self }
+}
+
+impl IntoHelper<u64> for u64 {
+    fn do_into(&self) -> u64 { *self }
+}
+
+impl IntoHelper<EulerRot> for RotationOrder {
+    fn do_into(&self) -> EulerRot { 
+        (*self).into()  // Use the existing From<RotationOrder> for EulerRot impl
+    }
+}
+
+impl IntoHelper<InheritType> for InheritType {
+    fn do_into(&self) -> InheritType { *self }
+}
+
+
 macro_rules! impl_loadable {
     ( $( $loader:expr => $target:ty ),* $(,)? ) => {
         $(
@@ -215,10 +307,10 @@ macro_rules! impl_loadable {
         impl Loadable for $target {
             fn get_property(properties: ObjectProperties, attribute: &str) -> anyhow::Result<Self> {
                 let loader = $loader;
-                let property= properties.get_property(attribute).ok_or_else(||
+                let property = properties.get_property(attribute).ok_or_else(||
                     anyhow::anyhow!("no {attribute} in properties when decoding {}", stringify!($target))
                 )?;
-                Ok(loader.load(&property)?.into())
+                Ok(loader.load(&property)?.do_into())
             }
         }
     };

--- a/src/utils/triangulate.rs
+++ b/src/utils/triangulate.rs
@@ -161,7 +161,7 @@ pub fn triangulate(
 /// Returns the vector.
 fn get_vec(pvs: &PolygonVertices<'_>, pvi: PolygonVertexIndex) -> anyhow::Result<DVec3> {
     pvs.control_point(pvi)
-        .map(Into::into)
+        .map(|p| DVec3::from((p.x, p.y, p.z)))
         .ok_or_else(|| anyhow!("Index out of range: {pvi:?}"))
 }
 


### PR DESCRIPTION
This PR updates bevy_mod_fbx to be compatible with Bevy 0.15. Changes include:

- Updating Bevy dependencies to 0.15
- Resolving API changes and breaking changes from Bevy 0.15
- Adjusting systems, resources, and plugin initialization to align with the latest Bevy architecture
- Ensuring compatibility with Bevy's latest asset pipeline and rendering updates

Tested with sample FBX models to confirm proper loading and scene integration.